### PR TITLE
fix: add visible analytics navigation link

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -532,6 +532,7 @@
                     </div>
                 </div>
             </div>
+            <a href="analytics/">Analytics</a>
             <button class="lang-switch" onclick="switchLanguage()">EN</button>
         </nav>
     </header>

--- a/index.html
+++ b/index.html
@@ -1490,6 +1490,7 @@
                 </div>
                 <div class="nav-item">
                     <a href="contact.html" data-i18n="nav_contact">Contact</a>
+                <a href="analytics/">Analytics</a>
                     <div class="dropdown">
                         <a href="contact.html" data-i18n="contact_form">Contact Form</a>
                         <a href="https://x.com/SundererD27468" target="_blank" rel="noopener noreferrer" data-i18n="contact_x">X (Twitter)</a>

--- a/profile.html
+++ b/profile.html
@@ -923,6 +923,7 @@
                 </div>
                 <div class="nav-item">
                     <a href="contact.html" data-i18n="nav_contact">Contact</a>
+                <a href="analytics/">Analytics</a>
                     <div class="dropdown">
                         <a href="contact.html" data-i18n="contact_form">Contact Form</a>
                         <a href="https://x.com/SundererD27468" target="_blank" rel="noopener noreferrer" data-i18n="contact_x">X (Twitter)</a>

--- a/projects.html
+++ b/projects.html
@@ -1210,6 +1210,7 @@
                 </div>
                 <div class="nav-item">
                     <a href="contact.html" data-i18n="nav_contact">Contact</a>
+                <a href="analytics/">Analytics</a>
                     <div class="dropdown">
                         <a href="contact.html" data-i18n="contact_form">Contact Form</a>
                         <a href="https://x.com/SundererD27468" target="_blank" rel="noopener noreferrer" data-i18n="contact_x">X (Twitter)</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,71 +7,71 @@
     <!-- Top Page -->
     <url>
         <loc>https://tenormusica2024.github.io/portfolio/</loc>
-        <lastmod>2026-04-06</lastmod>
+        <lastmod>2026-04-24</lastmod>
     </url>
 
     <!-- Projects Page -->
     <url>
         <loc>https://tenormusica2024.github.io/portfolio/projects.html</loc>
-        <lastmod>2026-04-06</lastmod>
+        <lastmod>2026-04-24</lastmod>
     </url>
 
     <!-- Profile Page -->
     <url>
         <loc>https://tenormusica2024.github.io/portfolio/profile.html</loc>
-        <lastmod>2026-04-06</lastmod>
+        <lastmod>2026-04-24</lastmod>
     </url>
 
     <!-- Contact Page -->
     <url>
         <loc>https://tenormusica2024.github.io/portfolio/contact.html</loc>
-        <lastmod>2026-04-06</lastmod>
+        <lastmod>2026-04-24</lastmod>
     </url>
 
     <!-- Presentations Page -->
     <url>
         <loc>https://tenormusica2024.github.io/portfolio/presentations.html</loc>
-        <lastmod>2026-04-06</lastmod>
+        <lastmod>2026-04-24</lastmod>
     </url>
 
     <!-- Archive Page -->
     <url>
         <loc>https://tenormusica2024.github.io/portfolio/archive.html</loc>
-        <lastmod>2026-04-06</lastmod>
+        <lastmod>2026-04-24</lastmod>
     </url>
 
     <!-- AI Trends Page -->
     <url>
         <loc>https://tenormusica2024.github.io/portfolio/ai-trends.html</loc>
-        <lastmod>2026-04-06</lastmod>
+        <lastmod>2026-04-24</lastmod>
     </url>
 
     <!-- Code Reviewer System Page -->
     <url>
         <loc>https://tenormusica2024.github.io/portfolio/code-reviewer-system.html</loc>
-        <lastmod>2026-04-06</lastmod>
+        <lastmod>2026-04-24</lastmod>
     </url>
 
     <!-- Privacy Policy -->
     <url>
         <loc>https://tenormusica2024.github.io/portfolio/privacy.html</loc>
-        <lastmod>2026-04-06</lastmod>
+        <lastmod>2026-04-24</lastmod>
     </url>
 
     <!-- Designer Portfolio -->
     <url>
         <loc>https://tenormusica2024.github.io/portfolio/designer-portfolio/index.html</loc>
-        <lastmod>2026-04-06</lastmod>
+        <lastmod>2026-04-24</lastmod>
     </url>
 
     <url>
         <loc>https://tenormusica2024.github.io/portfolio/designer-portfolio/about.html</loc>
-        <lastmod>2026-04-06</lastmod>
+        <lastmod>2026-04-24</lastmod>
     </url>
 
     <url>
         <loc>https://tenormusica2024.github.io/portfolio/designer-portfolio/works.html</loc>
-        <lastmod>2026-04-06</lastmod>
+        <lastmod>2026-04-24</lastmod>
     </url>
 
 </urlset>


### PR DESCRIPTION
## Summary\n- add a visible Analytics link to the main nav on key C2C pages\n- keep the existing footer link, but make the dashboard discoverable without scrolling\n\n## Pages\n- index.html\n- projects.html\n- profile.html\n- contact.html\n