### PR TITLE
revert: remove analytics header nav link

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -532,7 +532,6 @@
                     </div>
                 </div>
             </div>
-            <a href="analytics/">Analytics</a>
             <button class="lang-switch" onclick="switchLanguage()">EN</button>
         </nav>
     </header>

--- a/index.html
+++ b/index.html
@@ -1490,7 +1490,6 @@
                 </div>
                 <div class="nav-item">
                     <a href="contact.html" data-i18n="nav_contact">Contact</a>
-                <a href="analytics/">Analytics</a>
                     <div class="dropdown">
                         <a href="contact.html" data-i18n="contact_form">Contact Form</a>
                         <a href="https://x.com/SundererD27468" target="_blank" rel="noopener noreferrer" data-i18n="contact_x">X (Twitter)</a>

--- a/profile.html
+++ b/profile.html
@@ -923,7 +923,6 @@
                 </div>
                 <div class="nav-item">
                     <a href="contact.html" data-i18n="nav_contact">Contact</a>
-                <a href="analytics/">Analytics</a>
                     <div class="dropdown">
                         <a href="contact.html" data-i18n="contact_form">Contact Form</a>
                         <a href="https://x.com/SundererD27468" target="_blank" rel="noopener noreferrer" data-i18n="contact_x">X (Twitter)</a>

--- a/projects.html
+++ b/projects.html
@@ -1210,7 +1210,6 @@
                 </div>
                 <div class="nav-item">
                     <a href="contact.html" data-i18n="nav_contact">Contact</a>
-                <a href="analytics/">Analytics</a>
                     <div class="dropdown">
                         <a href="contact.html" data-i18n="contact_form">Contact Form</a>
                         <a href="https://x.com/SundererD27468" target="_blank" rel="noopener noreferrer" data-i18n="contact_x">X (Twitter)</a>


### PR DESCRIPTION
## Summary\n- revert the visible Analytics header link added on C2C pages\n- keep the analytics page comparison section itself unchanged\n\n## Reason\nThe request was to place the access trend display inside the analytics page, not to add a new header navigation entry on site pages.\n